### PR TITLE
Add Stage Manager style window hiding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Windows Stage Manager
+
+This project is an experimental window management tool inspired by macOS Stage Manager. It is written in C++ and uses Win32 and DWM APIs.
+Recent work integrates ideas from the open source [Stage Manager for Windows](https://github.com/awaescher/StageManager) project. Windows are grouped and hidden when inactive to mimic macOS Stage Manager.
+
+## Building with Visual Studio
+
+1. Install **Visual Studio 2022** (or later) with the **Desktop development with C++** workload and the Windows 10/11 SDK.
+2. In Visual Studio select **File > Open > CMake...** and choose the `WindowsStageManager` folder.
+3. Visual Studio will configure the project automatically. You can also configure from the Developer PowerShell:
+
+   ```
+   cmake -S WindowsStageManager -B build
+   ```
+
+4. Build the `WindowsStageManager` target in your chosen configuration (Debug/Release).
+5. Run the application from Visual Studio or from `build/WindowsStageManager.exe`.
+
+## Project Structure
+
+- **WindowsStageManager/** - CMake project containing the source
+  - `src/core` - `WindowManager` and `StageManager` classes
+  - `src/events` - event hooks
+  - `src/ui` - thumbnail renderer and layout system
+  - `src/utils` - helper utilities
+  - `include` - public headers
+
+The project links against `user32.lib`, `dwmapi.lib`, `gdi32.lib`, `ole32.lib`, and `oleaut32.lib` which are included with the Windows SDK.
+

--- a/WindowsStageManager/CMakeLists.txt
+++ b/WindowsStageManager/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.15)
+project(WindowsStageManager)
+
+set(CMAKE_CXX_STANDARD 17)
+
+file(GLOB CORE_SRC "src/core/*.cpp")
+file(GLOB EVENTS_SRC "src/events/*.cpp")
+file(GLOB UI_SRC "src/ui/*.cpp")
+file(GLOB UTILS_SRC "src/utils/*.cpp")
+set(API_SRC src/StageManagerAPI.cpp)
+
+add_executable(WindowsStageManager
+    ${CORE_SRC}
+    ${EVENTS_SRC}
+    ${UI_SRC}
+    ${UTILS_SRC}
+    ${API_SRC}
+    src/main.cpp)
+
+target_include_directories(WindowsStageManager PRIVATE src include)
+
+target_link_libraries(WindowsStageManager
+    user32
+    dwmapi
+    gdi32
+    ole32
+    oleaut32)
+
+add_definitions(-DUNICODE -D_UNICODE)

--- a/WindowsStageManager/include/StageManagerAPI.h
+++ b/WindowsStageManager/include/StageManagerAPI.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <windows.h>
+
+// Public API placeholder
+namespace StageManagerAPI {
+    void Show();
+    void Hide();
+}

--- a/WindowsStageManager/src/StageManagerAPI.cpp
+++ b/WindowsStageManager/src/StageManagerAPI.cpp
@@ -1,0 +1,14 @@
+#include "core/StageManager.h"
+#include "../include/StageManagerAPI.h"
+
+static StageManager g_stageManager;
+
+namespace StageManagerAPI {
+void Show() {
+    g_stageManager.ActivateStageManager();
+}
+
+void Hide() {
+    g_stageManager.DeactivateStageManager();
+}
+}

--- a/WindowsStageManager/src/core/StageManager.cpp
+++ b/WindowsStageManager/src/core/StageManager.cpp
@@ -1,0 +1,142 @@
+#include "StageManager.h"
+#include <algorithm>
+
+StageManager* StageManager::instance = nullptr;
+
+StageManager::StageManager() {
+    instance = this;
+    thumbnailRenderer = new ThumbnailRenderer(nullptr);
+}
+
+StageManager::~StageManager() {
+    if (sidebarWindow) {
+        DestroyWindow(sidebarWindow);
+        sidebarWindow = nullptr;
+    }
+    delete thumbnailRenderer;
+}
+
+void StageManager::ActivateStageManager() {
+    if (isActive) return;
+    isActive = true;
+
+    WindowManager* wm = WindowManager::GetInstance();
+    wm->EnumerateWindows();
+    appGroups.clear();
+
+    AppGroup group{};
+    group.isActive = true;
+    group.windows = wm->GetManagedWindows();
+    appGroups[0] = group;
+
+    CreateSidebar();
+    UpdateSidebar();
+    UpdateGroupVisibility();
+}
+
+void StageManager::DeactivateStageManager() {
+    isActive = false;
+    if (sidebarWindow) {
+        DestroyWindow(sidebarWindow);
+        sidebarWindow = nullptr;
+    }
+    WindowManager* wm = WindowManager::GetInstance();
+    for (auto& [id, group] : appGroups) {
+        for (HWND hwnd : group.windows) {
+            wm->ShowWindowHandle(hwnd);
+        }
+    }
+}
+
+void StageManager::CreateSidebar() {
+    if (sidebarWindow) return;
+
+    WNDCLASS wc{};
+    wc.lpfnWndProc = SidebarProc;
+    wc.hInstance = GetModuleHandle(nullptr);
+    wc.lpszClassName = L"StageManagerSidebar";
+    RegisterClass(&wc);
+
+    sidebarWindow = CreateWindowExW(WS_EX_TOPMOST | WS_EX_TOOLWINDOW,
+                                   wc.lpszClassName,
+                                   L"Stage Manager",
+                                   WS_POPUP,
+                                   0, 0, 200, GetSystemMetrics(SM_CYSCREEN),
+                                   nullptr, nullptr, wc.hInstance, nullptr);
+    ShowWindow(sidebarWindow, SW_SHOWNOACTIVATE);
+}
+
+void StageManager::UpdateSidebar() {
+    if (!sidebarWindow) return;
+    InvalidateRect(sidebarWindow, nullptr, TRUE);
+}
+
+void StageManager::SwitchToGroup(int groupId) {
+    for (auto& [id, group] : appGroups) {
+        group.isActive = (id == groupId);
+    }
+    ArrangeActiveGroup();
+}
+
+void StageManager::AddWindowToGroup(HWND hwnd, int groupId) {
+    appGroups[groupId].windows.push_back(hwnd);
+}
+
+void StageManager::RemoveWindowFromGroup(HWND hwnd) {
+    for (auto& [id, group] : appGroups) {
+        auto it = std::find(group.windows.begin(), group.windows.end(), hwnd);
+        if (it != group.windows.end()) {
+            group.windows.erase(it);
+            break;
+        }
+    }
+}
+
+void StageManager::ArrangeActiveGroup() {
+    for (auto& [id, group] : appGroups) {
+        if (!group.isActive) continue;
+        int x = 220;
+        int y = 0;
+        int width = 800;
+        int height = 600;
+        WindowManager* wm = WindowManager::GetInstance();
+        for (HWND hwnd : group.windows) {
+            wm->SetWindowPosition(hwnd, x, y, width, height);
+            x += 30; y += 30;
+        }
+        break;
+    }
+
+    UpdateGroupVisibility();
+}
+
+void StageManager::UpdateGroupVisibility() {
+    WindowManager* wm = WindowManager::GetInstance();
+    for (auto& [id, group] : appGroups) {
+        for (HWND hwnd : group.windows) {
+            if (group.isActive) {
+                wm->ShowWindowHandle(hwnd);
+            } else {
+                wm->HideWindowHandle(hwnd);
+            }
+        }
+    }
+}
+
+void StageManager::CalculateWindowPositions() {
+    // Placeholder for future layout calculations
+}
+
+void StageManager::AnimateTransition() {
+    // Placeholder for transition animations
+}
+
+LRESULT CALLBACK StageManager::SidebarProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    switch (msg) {
+        case WM_DESTROY:
+            instance->sidebarWindow = nullptr;
+            return 0;
+        default:
+            return DefWindowProc(hwnd, msg, wParam, lParam);
+    }
+}

--- a/WindowsStageManager/src/core/StageManager.h
+++ b/WindowsStageManager/src/core/StageManager.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "WindowManager.h"
+#include "../ui/ThumbnailRenderer.h"
+#include <map>
+#include <vector>
+
+struct AppGroup {
+    std::vector<HWND> windows;
+    POINT position{};
+    SIZE size{};
+    bool isActive{false};
+};
+
+class StageManager {
+private:
+    std::map<int, AppGroup> appGroups;
+    ThumbnailRenderer* thumbnailRenderer{nullptr};
+    HWND sidebarWindow{nullptr};
+    bool isActive{false};
+    static StageManager* instance;
+    static LRESULT CALLBACK SidebarProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+public:
+    StageManager();
+    ~StageManager();
+
+    void ActivateStageManager();
+    void DeactivateStageManager();
+    void CreateSidebar();
+    void UpdateSidebar();
+    void SwitchToGroup(int groupId);
+    void AddWindowToGroup(HWND hwnd, int groupId);
+    void RemoveWindowFromGroup(HWND hwnd);
+
+    void ArrangeActiveGroup();
+    void UpdateGroupVisibility();
+    void CalculateWindowPositions();
+    void AnimateTransition();
+};

--- a/WindowsStageManager/src/core/WindowManager.cpp
+++ b/WindowsStageManager/src/core/WindowManager.cpp
@@ -1,0 +1,92 @@
+#include "WindowManager.h"
+#include <algorithm>
+
+WindowManager* WindowManager::instance = nullptr;
+
+WindowManager* WindowManager::GetInstance() {
+    if (!instance) {
+        instance = new WindowManager();
+    }
+    return instance;
+}
+
+bool WindowManager::Initialize() {
+    EnumerateWindows();
+    return true;
+}
+
+void WindowManager::Cleanup() {
+    if (eventHook) {
+        UnhookWinEvent(eventHook);
+        eventHook = nullptr;
+    }
+}
+
+void WindowManager::EnumerateWindows() {
+    managedWindows.clear();
+    EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL {
+        if (IsWindowVisible(hwnd) && !IsIconic(hwnd)) {
+            auto windows = reinterpret_cast<std::vector<HWND>*>(lParam);
+            windows->push_back(hwnd);
+        }
+        return TRUE;
+    }, reinterpret_cast<LPARAM>(&managedWindows));
+}
+
+void WindowManager::ArrangeWindows() {
+    // Placeholder layout logic
+    int x = 0;
+    int y = 0;
+    int width = 800;
+    int height = 600;
+    for (HWND hwnd : managedWindows) {
+        SetWindowPosition(hwnd, x, y, width, height);
+        x += 20; y += 20;
+    }
+}
+
+void WindowManager::SetWindowPosition(HWND hwnd, int x, int y, int width, int height) {
+    SetWindowPos(hwnd, HWND_TOP, x, y, width, height, SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+void WindowManager::ShowWindowHandle(HWND hwnd) {
+    ::ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+}
+
+void WindowManager::HideWindowHandle(HWND hwnd) {
+    ::ShowWindow(hwnd, SW_HIDE);
+}
+
+void CALLBACK WindowManager::WinEventProc(HWINEVENTHOOK hWinEventHook, DWORD event,
+                                          HWND hwnd, LONG idObject, LONG idChild,
+                                          DWORD dwEventThread, DWORD dwmsEventTime) {
+    if (idObject != OBJID_WINDOW) return;
+    WindowManager* manager = WindowManager::GetInstance();
+    switch (event) {
+        case EVENT_SYSTEM_FOREGROUND:
+            // Placeholder for activation handling
+            break;
+        case EVENT_OBJECT_CREATE:
+            manager->EnumerateWindows();
+            break;
+        case EVENT_OBJECT_DESTROY:
+            manager->EnumerateWindows();
+            break;
+    }
+}
+
+void WindowManager::CreateAppGroup(const std::vector<HWND>& windows) {
+    // TODO: implement grouping
+}
+
+void WindowManager::UpdateThumbnails() {
+    // TODO: implement thumbnail updating
+}
+
+void WindowManager::ShowStageManager() {
+    // TODO: show UI
+}
+
+void WindowManager::HideStageManager() {
+    // TODO: hide UI
+}

--- a/WindowsStageManager/src/core/WindowManager.h
+++ b/WindowsStageManager/src/core/WindowManager.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <windows.h>
+#include <dwmapi.h>
+#include <vector>
+
+class WindowManager {
+private:
+    HWINEVENTHOOK eventHook{};
+    std::vector<HWND> managedWindows;
+    static WindowManager* instance;
+
+    WindowManager() = default;
+
+public:
+    static WindowManager* GetInstance();
+    bool Initialize();
+    void Cleanup();
+    void EnumerateWindows();
+    void ArrangeWindows();
+    void SetWindowPosition(HWND hwnd, int x, int y, int width, int height);
+    void ShowWindowHandle(HWND hwnd);
+    void HideWindowHandle(HWND hwnd);
+    const std::vector<HWND>& GetManagedWindows() const { return managedWindows; }
+
+    static void CALLBACK WinEventProc(HWINEVENTHOOK hWinEventHook,
+                                      DWORD event,
+                                      HWND hwnd,
+                                      LONG idObject,
+                                      LONG idChild,
+                                      DWORD dwEventThread,
+                                      DWORD dwmsEventTime);
+
+    void CreateAppGroup(const std::vector<HWND>& windows);
+    void UpdateThumbnails();
+    void ShowStageManager();
+    void HideStageManager();
+};

--- a/WindowsStageManager/src/events/EventHandler.cpp
+++ b/WindowsStageManager/src/events/EventHandler.cpp
@@ -1,0 +1,13 @@
+#include "EventHandler.h"
+#include "../core/WindowManager.h"
+
+void EventHandler::Initialize() {
+    SetWinEventHook(
+        EVENT_SYSTEM_FOREGROUND,
+        EVENT_OBJECT_DESTROY,
+        NULL,
+        WindowManager::WinEventProc,
+        0,
+        0,
+        WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS);
+}

--- a/WindowsStageManager/src/events/EventHandler.h
+++ b/WindowsStageManager/src/events/EventHandler.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <windows.h>
+
+class EventHandler {
+public:
+    void Initialize();
+};

--- a/WindowsStageManager/src/events/HookManager.cpp
+++ b/WindowsStageManager/src/events/HookManager.cpp
@@ -1,0 +1,1 @@
+// Placeholder for future hook management implementation

--- a/WindowsStageManager/src/main.cpp
+++ b/WindowsStageManager/src/main.cpp
@@ -1,0 +1,25 @@
+#include <windows.h>
+#include "core/WindowManager.h"
+#include "core/StageManager.h"
+
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+                   LPSTR lpCmdLine, int nCmdShow) {
+    CoInitialize(NULL);
+
+    WindowManager* windowManager = WindowManager::GetInstance();
+    if (!windowManager->Initialize()) {
+        return -1;
+    }
+
+    StageManager stageManager;
+
+    MSG msg;
+    while (GetMessage(&msg, NULL, 0, 0)) {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+    }
+
+    windowManager->Cleanup();
+    CoUninitialize();
+    return static_cast<int>(msg.wParam);
+}

--- a/WindowsStageManager/src/ui/AnimationSystem.cpp
+++ b/WindowsStageManager/src/ui/AnimationSystem.cpp
@@ -1,0 +1,1 @@
+// Placeholder for animation system implementation

--- a/WindowsStageManager/src/ui/LayoutEngine.cpp
+++ b/WindowsStageManager/src/ui/LayoutEngine.cpp
@@ -1,0 +1,1 @@
+// Placeholder for layout engine implementation

--- a/WindowsStageManager/src/ui/ThumbnailRenderer.cpp
+++ b/WindowsStageManager/src/ui/ThumbnailRenderer.cpp
@@ -1,0 +1,44 @@
+#include "ThumbnailRenderer.h"
+
+ThumbnailRenderer::ThumbnailRenderer(HWND target) : targetWindow(target) {}
+
+ThumbnailRenderer::~ThumbnailRenderer() {
+    for (auto thumb : thumbnails) {
+        DwmUnregisterThumbnail(thumb);
+    }
+}
+
+HTHUMBNAIL ThumbnailRenderer::CreateThumbnail(HWND sourceWindow) {
+    HTHUMBNAIL thumb{};
+    if (SUCCEEDED(DwmRegisterThumbnail(targetWindow, sourceWindow, &thumb))) {
+        thumbnails.push_back(thumb);
+    }
+    return thumb;
+}
+
+void ThumbnailRenderer::UpdateThumbnail(HTHUMBNAIL thumbnail, const RECT& dest) {
+    DWM_THUMBNAIL_PROPERTIES props{};
+    props.dwFlags = DWM_TNP_RECTDESTINATION;
+    props.rcDestination = dest;
+    DwmUpdateThumbnailProperties(thumbnail, &props);
+}
+
+void ThumbnailRenderer::SetThumbnailOpacity(HTHUMBNAIL thumbnail, BYTE opacity) {
+    DWM_THUMBNAIL_PROPERTIES props{};
+    props.dwFlags = DWM_TNP_OPACITY;
+    props.opacity = opacity;
+    DwmUpdateThumbnailProperties(thumbnail, &props);
+}
+
+void ThumbnailRenderer::RemoveThumbnail(HTHUMBNAIL thumbnail) {
+    DwmUnregisterThumbnail(thumbnail);
+    thumbnails.erase(std::remove(thumbnails.begin(), thumbnails.end(), thumbnail), thumbnails.end());
+}
+
+void ThumbnailRenderer::RenderSidebarThumbnails() {
+    // TODO: render thumbnails in sidebar
+}
+
+void ThumbnailRenderer::UpdateThumbnailPositions() {
+    // TODO: update sidebar layout
+}

--- a/WindowsStageManager/src/ui/ThumbnailRenderer.h
+++ b/WindowsStageManager/src/ui/ThumbnailRenderer.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <windows.h>
+#include <dwmapi.h>
+#include <vector>
+
+class ThumbnailRenderer {
+private:
+    HWND targetWindow;
+    std::vector<HTHUMBNAIL> thumbnails;
+
+public:
+    ThumbnailRenderer(HWND target);
+    ~ThumbnailRenderer();
+
+    HTHUMBNAIL CreateThumbnail(HWND sourceWindow);
+    void UpdateThumbnail(HTHUMBNAIL thumbnail, const RECT& dest);
+    void SetThumbnailOpacity(HTHUMBNAIL thumbnail, BYTE opacity);
+    void RemoveThumbnail(HTHUMBNAIL thumbnail);
+
+    void RenderSidebarThumbnails();
+    void UpdateThumbnailPositions();
+};

--- a/WindowsStageManager/src/utils/WindowUtils.cpp
+++ b/WindowsStageManager/src/utils/WindowUtils.cpp
@@ -1,0 +1,15 @@
+#include "WindowUtils.h"
+
+namespace WindowUtils {
+bool IsAltTabWindow(HWND hwnd) {
+    if (!IsWindowVisible(hwnd)) return false;
+    HWND hwndTry, hwndWalk = NULL;
+    hwndTry = GetAncestor(hwnd, GA_ROOTOWNER);
+    while (hwndTry != hwndWalk) {
+        hwndWalk = hwndTry;
+        hwndTry = GetLastActivePopup(hwndWalk);
+        if (IsWindowVisible(hwndTry)) break;
+    }
+    return hwndWalk == hwnd;
+}
+}

--- a/WindowsStageManager/src/utils/WindowUtils.h
+++ b/WindowsStageManager/src/utils/WindowUtils.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <windows.h>
+
+namespace WindowUtils {
+    bool IsAltTabWindow(HWND hwnd);
+}


### PR DESCRIPTION
## Summary
- reference Stage Manager for Windows in README
- add helpers to show/hide windows
- populate a default window group on activation
- hide inactive groups like macOS Stage Manager

## Testing
- `cmake -S WindowsStageManager -B build`
- `cmake --build build` *(fails: missing windows.h)*

------
https://chatgpt.com/codex/tasks/task_e_68413b448a3083318fb786556e6922de